### PR TITLE
Update links due to JuliaIO org transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # CodecLz4
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/CodecLz4.jl/stable)
-[![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/CodecLz4.jl/latest)
-[![Build Status](https://travis-ci.com/invenia/CodecLz4.jl.svg?branch=master)](https://travis-ci.com/invenia/CodecLz4.jl)
-[![CodeCov](https://codecov.io/gh/invenia/CodecLz4.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/CodecLz4.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliaio.github.io/CodecLz4.jl/stable)
+[![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliaio.github.io/CodecLz4.jl/latest)
+[![Build Status](https://travis-ci.com/JuliaIO/CodecLz4.jl.svg?branch=master)](https://travis-ci.com/JuliaIO/CodecLz4.jl)
+[![CodeCov](https://codecov.io/gh/JuliaIO/CodecLz4.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaIO/CodecLz4.jl)
 
 Provides transcoding codecs for compression and decompression with LZ4. Source: [LZ4](https://github.com/lz4/lz4)
 The compression algorithm is similar to the compression available through [Blosc.jl](https://github.com/stevengj/Blosc.jl), but uses the LZ4 Frame format as opposed to the standard LZ4 or LZ4_HC formats.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,13 +6,13 @@ makedocs(;
     pages=[
         "Home" => "index.md",
     ],
-    repo="https://github.com/invenia/CodecLz4.jl/blob/{commit}{path}#L{line}",
+    repo="https://github.com/JuliaIO/CodecLz4.jl/blob/{commit}{path}#L{line}",
     sitename="CodecLz4.jl",
     authors="Invenia Technical Computing Corporation",
 )
 
 deploydocs(;
-    repo="github.com/invenia/CodecLz4.jl",
+    repo="github.com/JuliaIO/CodecLz4.jl",
     target="build",
     deps=nothing,
     make=nothing,

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,9 @@
 # CodecLz4
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/CodecLz4.jl/stable)
-[![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/CodecLz4.jl/latest)
-[![Build Status](https://travis-ci.org/invenia/CodecLz4.jl.svg?branch=master)](https://travis-ci.org/invenia/CodecLz4.jl)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/invenia/CodecLz4.jl?svg=true)](https://ci.appveyor.com/project/invenia/codeclz4-jl)
-[![CodeCov](https://codecov.io/gh/invenia/CodecLz4.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/CodecLz4.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliaio.github.io/CodecLz4.jl/stable)
+[![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliaio.github.io/CodecLz4.jl/latest)
+[![Build Status](https://travis-ci.com/JuliaIO/CodecLz4.jl.svg?branch=master)](https://travis-ci.com/JuliaIO/CodecLz4.jl)
+[![CodeCov](https://codecov.io/gh/JuliaIO/CodecLz4.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaIO/CodecLz4.jl)
 
 ```@autodocs
 Modules = [CodecLz4]


### PR DESCRIPTION
Part of: https://github.com/JuliaIO/CodecLz4.jl/issues/29. I also noticed an outdated Travis CI link and a left over Appveyor link.