### PR TITLE
Add GC-safe regions around some `ccall`s

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,8 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1'
+          - '1' # automatically expands to the latest stable 1.x release of Julia
+          - 'nightly'
         os:
           - ubuntu-latest
           - windows-latest

--- a/src/CodecLz4.jl
+++ b/src/CodecLz4.jl
@@ -22,6 +22,7 @@ end
 
 Base.showerror(io::IO, ex::LZ4Exception) = print(io, "$(ex.src): $(ex.msg)")
 
+include("gcsafe_ccall.jl")
 include("headers/lz4frame.jl")
 include("headers/lz4.jl")
 include("headers/lz4hc.jl")

--- a/src/gcsafe_ccall.jl
+++ b/src/gcsafe_ccall.jl
@@ -1,0 +1,70 @@
+## version of ccall that calls jl_gc_safe_enter|leave around the inner ccall
+# note that this is generally only safe with functions that do not call back into
+# Julia
+
+const HAS_CCALL_GCSAFE = VERSION >= v"1.13.0-DEV.70" || v"1.12-DEV.2029" <= VERSION < v"1.13-"
+
+"""
+    @gcsafe_ccall ...
+
+Call a foreign function just like [`@ccall`](https://docs.julialang.org/en/v1/base/c/#Base.@ccall), but marking it safe for the GC to run. This is
+useful for functions that may block, so that the GC isn't blocked from running, but may also
+be required to prevent deadlocks (see JuliaGPU/CUDA.jl#2261).
+
+Note that this is generally only safe with non-Julia C functions that do not call back into
+the Julia directly.
+"""
+macro gcsafe_ccall end
+export @gcsafe_ccall
+
+if HAS_CCALL_GCSAFE
+    macro gcsafe_ccall(expr)
+        exprs = Any[:(gc_safe = true), expr]
+        return Base.ccall_macro_lower((:ccall), Base.ccall_macro_parse(exprs)...)
+    end
+else
+    function ccall_macro_lower(func, rettype, types, args, nreq)
+        # instead of re-using ccall or Expr(:foreigncall) to perform argument conversion,
+        # we need to do so ourselves in order to insert a jl_gc_safe_enter|leave
+        # just around the inner ccall
+
+        cconvert_exprs = []
+        cconvert_args = []
+        for (typ, arg) in zip(types, args)
+            var = gensym("$(func)_cconvert")
+            push!(cconvert_args, var)
+            push!(cconvert_exprs, :($var = Base.cconvert($(esc(typ)), $(esc(arg)))))
+        end
+
+        unsafe_convert_exprs = []
+        unsafe_convert_args = []
+        for (typ, arg) in zip(types, cconvert_args)
+            var = gensym("$(func)_unsafe_convert")
+            push!(unsafe_convert_args, var)
+            push!(unsafe_convert_exprs, :($var = Base.unsafe_convert($(esc(typ)), $arg)))
+        end
+
+        call = quote
+            $(unsafe_convert_exprs...)
+
+            gc_state = @ccall(jl_gc_safe_enter()::Int8)
+            ret = ccall(
+                $(esc(func)), $(esc(rettype)), $(Expr(:tuple, map(esc, types)...)),
+                $(unsafe_convert_args...)
+            )
+            @ccall(jl_gc_safe_leave(gc_state::Int8)::Cvoid)
+            ret
+        end
+
+        return quote
+            @inline
+            $(cconvert_exprs...)
+            GC.@preserve $(cconvert_args...) $(call)
+        end
+    end
+
+    macro gcsafe_ccall(expr)
+        return ccall_macro_lower(Base.ccall_macro_parse(expr)...)
+    end
+end # HAS_CCALL_GCSAFE
+

--- a/src/gcsafe_ccall.jl
+++ b/src/gcsafe_ccall.jl
@@ -7,15 +7,14 @@ const HAS_CCALL_GCSAFE = VERSION >= v"1.13.0-DEV.70" || v"1.12-DEV.2029" <= VERS
 """
     @gcsafe_ccall ...
 
-Call a foreign function just like [`@ccall`](https://docs.julialang.org/en/v1/base/c/#Base.@ccall), but marking it safe for the GC to run. This is
-useful for functions that may block, so that the GC isn't blocked from running, but may also
-be required to prevent deadlocks (see JuliaGPU/CUDA.jl#2261).
+Call a foreign function just like [`@ccall`](https://docs.julialang.org/en/v1/base/c/#Base.@ccall),
+but marking it safe for the GC to run. This is useful for functions that may block, so that the GC
+isn't blocked from running, but may also be required to prevent deadlocks (see JuliaGPU/CUDA.jl#2261).
 
-Note that this is generally only safe with non-Julia C functions that do not call back into
-the Julia directly.
+Note that this is generally only safe with non-Julia C functions that do not call back into Julia
+directly.
 """
 macro gcsafe_ccall end
-export @gcsafe_ccall
 
 if HAS_CCALL_GCSAFE
     macro gcsafe_ccall(expr)

--- a/src/gcsafe_ccall.jl
+++ b/src/gcsafe_ccall.jl
@@ -57,7 +57,9 @@ else
         end
 
         return quote
-            @inline
+            @static if VERSION >= v"1.8"
+                @inline
+            end
             $(cconvert_exprs...)
             GC.@preserve $(cconvert_args...) $(call)
         end

--- a/src/headers/lz4.jl
+++ b/src/headers/lz4.jl
@@ -46,20 +46,7 @@ This function never writes outside `dst` buffer, nor read outside `source` buffe
 Returns the number of bytes written into buffer `dst` (necessarily <= dstcapacity)
 """
 function LZ4_compress_fast(src, dst, srcsize, dstcapacity, acceleration=1)
-    src = Base.cconvert(Ptr{UInt8}, src)
-    dst = Base.cconvert(Ptr{UInt8}, dst)
-    csrc = Base.unsafe_convert(Ptr{UInt8}, src)::Ptr{UInt8}
-    cdst = Base.unsafe_convert(Ptr{UInt8}, dst)::Ptr{UInt8}
-    srcsize = convert(Cint, srcsize)::Cint
-    dstcapacity = convert(Cint, dstcapacity)::Cint
-    acceleration = convert(Cint, acceleration)::Cint
-    GC.@preserve src dst begin
-        # Allow Julia to GC while compressing
-        gc_state = @ccall(jl_gc_safe_enter()::Int8)
-        ret = ccall((:LZ4_compress_fast, liblz4), Cint, (Ptr{UInt8}, Ptr{UInt8}, Cint, Cint, Cint), csrc, cdst, srcsize, dstcapacity, acceleration)
-        # Leave GC-safe region, waiting for GC to complete if it's running
-        @ccall(jl_gc_safe_leave(gc_state::Int8)::Cvoid)
-    end
+    ret = @gcsafe_ccall liblz4.LZ4_compress_fast(src::Ptr{UInt8}, dst::Ptr{UInt8}, srcsize::Cint, dstcapacity::Cint, acceleration::Cint)::Cint
     check_compression_error(ret, "LZ4_compress_fast")
 end
 
@@ -76,20 +63,7 @@ or fill `dst` buffer completely with as much data as possible from `src`.
 Returns number of bytes written into `dst` (necessarily <= dstcapacity)
 """
 function LZ4_compress_destSize(src, dst, srcsize, dstcapacity)
-    src = Base.cconvert(Ptr{UInt8}, src)
-    dst = Base.cconvert(Ptr{UInt8}, dst)
-    srcsize = Base.cconvert(Ptr{Cint}, srcsize)
-    csrc = Base.unsafe_convert(Ptr{UInt8}, src)::Ptr{UInt8}
-    cdst = Base.unsafe_convert(Ptr{UInt8}, dst)::Ptr{UInt8}
-    csrcsize = Base.unsafe_convert(Ptr{Cint}, srcsize)::Ptr{Cint}
-    dstcapacity = convert(Cint, dstcapacity)::Cint
-    GC.@preserve src dst srcsize begin
-        # Allow Julia to GC while compressing
-        gc_state = @ccall(jl_gc_safe_enter()::Int8)
-        ret = ccall((:LZ4_compress_destSize, liblz4), Cint, (Ptr{UInt8}, Ptr{UInt8}, Ptr{Cint}, Cint), csrc, cdst, csrcsize, dstcapacity)
-        # Leave GC-safe region, waiting for GC to complete if it's running
-        @ccall(jl_gc_safe_leave(gc_state::Int8)::Cvoid)
-    end
+    ret = @gcsafe_ccall liblz4.LZ4_compress_destSize(src::Ptr{UInt8}, dst::Ptr{UInt8}, srcsize::Ptr{Cint}, dstcapacity::Cint)::Cint
     check_compression_error(ret, "LZ4_compress_destSize")
 end
 
@@ -176,19 +150,7 @@ dstcapacity : is the size of destination buffer, which must be already allocated
 Returns the number of bytes decompressed into destination buffer (necessarily <= dstcapacity)
 """
 function LZ4_decompress_safe(src, dst, cmpsize, dstcapacity)
-    src = Base.cconvert(Ptr{UInt8}, src)
-    dst = Base.cconvert(Ptr{UInt8}, dst)
-    csrc = Base.unsafe_convert(Ptr{UInt8}, src)::Ptr{UInt8}
-    cdst = Base.unsafe_convert(Ptr{UInt8}, dst)::Ptr{UInt8}
-    cmpsize = convert(Cint, cmpsize)::Cint
-    dstcapacity = convert(Cint, dstcapacity)::Cint
-    GC.@preserve src dst begin
-        # Allow Julia to GC while decompressing
-        gc_state = @ccall(jl_gc_safe_enter()::Int8)
-        ret = ccall((:LZ4_decompress_safe, liblz4), Cint, (Ptr{UInt8}, Ptr{UInt8}, Cint, Cint),csrc, cdst, cmpsize, dstcapacity)
-        # Leave GC-safe region, waiting for GC to complete if it's running
-        @ccall(jl_gc_safe_leave(gc_state::Int8)::Cvoid)
-    end
+    ret = @gcsafe_ccall liblz4.LZ4_decompress_safe(src::Ptr{UInt8}, dst::Ptr{UInt8}, cmpsize::Cint, dstcapacity::Cint)::Cint
     check_decompression_error(ret, "LZ4_decompress_safe")
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 CodecLz4 = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestsForCodecPackages = "c2e61002-3542-480d-8b3c-5f05cc4f8554"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"

--- a/test/gcsafe_ccall.jl
+++ b/test/gcsafe_ccall.jl
@@ -1,0 +1,24 @@
+using CodecLz4
+using InteractiveUtils
+
+@testset "gcsafe_ccall" begin
+    function gc_safe_ccall()
+        # jl_symbol is marked as JL_NOTSAFEPOINT
+        CodecLz4.@gcsafe_ccall jl_symbol("gc_safe_ccall"::Cstring)::Symbol
+    end
+
+    let llvm = sprint(code_llvm, gc_safe_ccall, ())
+        # check that the call works
+        @test gc_safe_ccall() isa Symbol
+        # v1.10 is hard to test since ccall are just raw runtime pointers
+        if VERSION >= v"1.11"
+            if !CodecLz4.HAS_CCALL_GCSAFE
+                # check for the gc_safe store
+                @test occursin("jl_gc_safe_enter", llvm)
+                @test occursin("jl_gc_safe_leave", llvm)
+            else
+                @test occursin("store atomic i8 2", llvm)
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using CodecLz4
 using Test
 
 @testset "CodecLz4.jl" begin
+    include("gcsafe_ccall.jl")
     include("headers/lz4.jl")
     include("headers/lz4frame.jl")
     include("headers/lz4hc.jl")


### PR DESCRIPTION
Specifically, around `LZ4_compress_fast`, `LZ4_compress_destSize` and `LZ4_decompress_safe`. If these are called on large data (on the order of GBs), the calls could take multiple seconds during which GC cannot run without these GC-safe regions.

Ref: https://github.com/JuliaLang/julia/issues/51574

Please note that when https://github.com/JuliaLang/julia/pull/49933 lands, these changes should be subsumed by whatever that requires.