### PR TITLE
Fix C to Julia translation errors in `SimpleDoubleBuffer`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
     tags: ['*']
   pull_request:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,14 +21,12 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.7'
-          - '1.8'
           - '1.9'
           - '1'
         os:
-          # - ubuntu-latest
+          - ubuntu-latest
           - windows-latest
-          # - macos-latest
+          - macos-latest
         arch:
           - x64
     steps:
@@ -38,7 +36,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
           show-versioninfo: true
-      # - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         version:
           - '1.6'
+          - '1.7'
           - '1'
         os:
           - ubuntu-latest
@@ -34,6 +35,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+          show-versioninfo: true
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,11 +22,12 @@ jobs:
         version:
           - '1.6'
           - '1.7'
+          - '1.8'
           - '1'
         os:
-          - ubuntu-latest
+          # - ubuntu-latest
           - windows-latest
-          - macos-latest
+          # - macos-latest
         arch:
           - x64
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
           - '1.6'
           - '1.7'
           - '1.8'
+          - '1.9'
           - '1'
         os:
           # - ubuntu-latest
@@ -37,7 +38,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
           show-versioninfo: true
-      - uses: julia-actions/cache@v1
+      # - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
This fixes some bugs in `SimpleDoubleBuffer` that seem to come from translating https://github.com/lz4/lz4/blob/dev/examples/blockStreaming_doubleBuffer.c to Julia for `LZ4FastCompressor`

This also enables CI on the master branch.