### PR TITLE
Add warning about `LZ4FastCompressor` and `LZ4HCCompressor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Codecs for the standard LZ4 and LZ4_HC formats are also provided as `LZ4FastComp
 These codecs follow the [LZ4 streaming examples](https://github.com/lz4/lz4/tree/master/examples),
 breaking the data into blocks and prepending each compressed block with a size.
 Data compressed with these codecs can be decompressed with `LZ4SafeDecompressor`.
+> [!CAUTION]
+> `LZ4FastCompressor` and `LZ4HCCompressor` output is not compatible with lz4frame and is platform dependent.
+
 
 Non-streaming functions are included via `lz4_compress`, `lz4_hc_compress`, and `lz4_decompress`.
 These should work with most other standard lz4 implementations.


### PR DESCRIPTION
Add the warning from https://github.com/lz4/lz4/blob/dev/examples/blockStreaming_doubleBuffer.md

The format used by these compressors is platform-specific, so they should never be used to archive data.

As noted in https://github.com/lz4/lz4/issues/1318#issuecomment-1864886910 and https://github.com/lz4/lz4/blob/dev/examples/blockStreaming_doubleBuffer.md this is a very advanced API, intended for systems with limited memory, and I'm not sure we should support these in this package.