### PR TITLE
Add GC preserve before unsafe_copyto!

### DIFF
--- a/src/frame_compression.jl
+++ b/src/frame_compression.jl
@@ -124,7 +124,7 @@ function TranscodingStreams.process(codec::LZ4FrameCompressor, input::Memory, ou
             return (data_read, data_written, :error)
         end
         data_written = sizeof(codec.header)
-        unsafe_copyto!(output.ptr, pointer(codec.header), data_written)
+        GC.@preserve codec unsafe_copyto!(output.ptr, pointer(codec.header), data_written)
         codec.write_header = false
     end
 


### PR DESCRIPTION
This is to be extra safe, this is probably not needed because `codec` is used later on in the function, but maybe the compiler could rearrange the order.