### PR TITLE
`test_roundtrip_seekstart`

### DIFF
--- a/test/frame_compression.jl
+++ b/test/frame_compression.jl
@@ -22,6 +22,12 @@ erat ex bibendum ipsum, sed varius ipsum ipsum vitae dui.
     @test sizeof(decompressed) > sizeof(compressed)
     @test decompressed == Vector{UInt8}(text)
 
+    TranscodingStreams.test_roundtrip_read(LZ4FrameCompressorStream, LZ4FrameDecompressorStream)
+    TranscodingStreams.test_roundtrip_write(LZ4FrameCompressorStream, LZ4FrameDecompressorStream)
+    TranscodingStreams.test_roundtrip_lines(LZ4FrameCompressorStream, LZ4FrameDecompressorStream)
+    if isdefined(TranscodingStreams, :test_roundtrip_seekstart)
+        TranscodingStreams.test_roundtrip_seekstart(LZ4FrameCompressorStream, LZ4FrameDecompressorStream)
+    end
     test_roundtrip_fileio(LZ4FrameCompressor, LZ4FrameDecompressor)
     test_roundtrip_transcode(LZ4FrameCompressor, LZ4FrameDecompressor)
 


### PR DESCRIPTION
[`test_roundtrip_seekstart`](https://github.com/JuliaIO/TranscodingStreams.jl/blob/d92fd8b9fb0b9314d82b40a96774f7f745b4dab1/ext/TestExt.jl#L65-L81) adds additional test coverage for resetting the compression session.

Ref: https://github.com/JuliaIO/TranscodingStreams.jl/issues/217