### PR TITLE
add `GC.@preserve` to tests

### DIFF
--- a/test/lz4_compression.jl
+++ b/test/lz4_compression.jl
@@ -58,16 +58,23 @@
 
     @testset "Errors" begin
         @testset "Uninitialized" begin
-            input = Memory(Vector{UInt8}(text))
-            output = Memory(Vector{UInt8}(undef, 1280))
-            not_initialized = LZ4FastCompressor()
-            @test TranscodingStreams.startproc(not_initialized, :read, Error()) == :error
-            @test TranscodingStreams.process(not_initialized, input, output, Error()) == (0, 0, :error)
+            input_data = Vector{UInt8}(text)
+            output_data = Vector{UInt8}(undef, 1280)
+            GC.@preserve input_data output_data begin
+                input = Memory(pointer(input_data), length(input_data))
+                output = Memory(pointer(output_data), length(output_data))
+                not_initialized = LZ4FastCompressor()
+                @test TranscodingStreams.startproc(not_initialized, :read, Error()) == :error
+                @test TranscodingStreams.process(not_initialized, input, output, Error()) == (0, 0, :error)
 
-            compressed = Memory(transcode(LZ4FastCompressor, text))
-            not_initialized = LZ4SafeDecompressor()
-            @test TranscodingStreams.startproc(not_initialized, :read, Error()) == :error
-            @test TranscodingStreams.process(not_initialized, compressed, output, Error()) == (0, 0, :error)
+                compressed_data = transcode(LZ4FastCompressor, text)
+                GC.@preserve compressed_data begin
+                    compressed = Memory(pointer(compressed_data), length(compressed_data))
+                    not_initialized = LZ4SafeDecompressor()
+                    @test TranscodingStreams.startproc(not_initialized, :read, Error()) == :error
+                    @test TranscodingStreams.process(not_initialized, compressed, output, Error()) == (0, 0, :error)
+                end
+            end
         end
 
         @testset "Bad Input" begin
@@ -85,50 +92,62 @@
 
         @testset "Bad Buffer Size" begin
             # Decompression with too-small block_size
-            output = Memory(Vector{UInt8}(undef, 1024))
-            compressed = transcode(LZ4FastCompressor, text)
-            decompressor = LZ4SafeDecompressor(; block_size = 200)
-            try
-                @test_nowarn TranscodingStreams.initialize(decompressor)
-                @test TranscodingStreams.startproc(decompressor, :read, Error()) == :ok
-                err = Error()
-                @test TranscodingStreams.process(decompressor, Memory(compressed), output, err) == (0, 0, :error)
+            output_data = Vector{UInt8}(undef, 1024)
+            compressed_data = transcode(LZ4FastCompressor, text)
+            GC.@preserve output_data compressed begin
+                output = Memory(pointer(output_data), length(output_data))
+                compressed = Memory(pointer(compressed_data), length(compressed_data))
+                decompressor = LZ4SafeDecompressor(; block_size = 200)
+                try
+                    @test_nowarn TranscodingStreams.initialize(decompressor)
+                    @test TranscodingStreams.startproc(decompressor, :read, Error()) == :ok
+                    err = Error()
+                    @test TranscodingStreams.process(decompressor, compressed, output, err) == (0, 0, :error)
 
-                @test err[] isa CodecLz4.LZ4Exception
-                @test err[].msg == "Decompression failed."
-            finally
-                TranscodingStreams.finalize(decompressor)
+                    @test err[] isa CodecLz4.LZ4Exception
+                    @test err[].msg == "Decompression failed."
+                finally
+                    TranscodingStreams.finalize(decompressor)
+                end
             end
 
             # Compression into too-small buffer
-            input = Memory(Vector{UInt8}(text))
-            output = Memory(Vector{UInt8}(undef, 1))
-            compressor = LZ4FastCompressor()
+            input_data = Vector{UInt8}(text)
+            output_data = Vector{UInt8}(undef, 1)
+            GC.@preserve input_data output_data begin
+                input = Memory(pointer(input_data), length(input_data))
+                output = Memory(pointer(output_data), length(output_data))
+                compressor = LZ4FastCompressor()
 
-            try
-                @test_nowarn TranscodingStreams.initialize(compressor)
-                @test TranscodingStreams.startproc(compressor, :read, Error()) == :ok
-                err = Error()
-                @test TranscodingStreams.process(compressor, input, output, err) == (0, 0, :error)
+                try
+                    @test_nowarn TranscodingStreams.initialize(compressor)
+                    @test TranscodingStreams.startproc(compressor, :read, Error()) == :ok
+                    err = Error()
+                    @test TranscodingStreams.process(compressor, input, output, err) == (0, 0, :error)
 
-                @test err[] isa BoundsError
-            finally
-                TranscodingStreams.finalize(compressor)
+                    @test err[] isa BoundsError
+                finally
+                    TranscodingStreams.finalize(compressor)
+                end
             end
 
             # Decompression into too-small buffer
-            output = Memory(Vector{UInt8}(undef, 1))
-            compressed = transcode(LZ4FastCompressor, text)
-            decompressor = LZ4SafeDecompressor()
-            try
-                @test_nowarn TranscodingStreams.initialize(decompressor)
-                @test TranscodingStreams.startproc(decompressor, :read, Error()) == :ok
-                err = Error()
-                @test TranscodingStreams.process(decompressor, Memory(compressed), output, err) == (0, 0, :error)
+            output_data = Vector{UInt8}(undef, 1)
+            compressed_data = transcode(LZ4FastCompressor, text)
+            GC.@preserve output_data compressed_data begin
+                output = Memory(pointer(output_data), length(output_data))
+                compressed = Memory(pointer(compressed_data), length(compressed_data))
+                decompressor = LZ4SafeDecompressor()
+                try
+                    @test_nowarn TranscodingStreams.initialize(decompressor)
+                    @test TranscodingStreams.startproc(decompressor, :read, Error()) == :ok
+                    err = Error()
+                    @test TranscodingStreams.process(decompressor, compressed, output, err) == (0, 0, :error)
 
-                @test err[] isa BoundsError
-            finally
-                TranscodingStreams.finalize(decompressor)
+                    @test err[] isa BoundsError
+                finally
+                    TranscodingStreams.finalize(decompressor)
+                end
             end
         end
     end


### PR DESCRIPTION
This PR adds GC preserve to places where `pointer` is used. The `Memory(::Vector{UInt8})` method internally uses `pointer` and does not protect its arguments from GC, so I am replacing these with explicit calls to `pointer` to clarify this. 

Ref: https://github.com/JuliaIO/TranscodingStreams.jl/pull/219